### PR TITLE
Feat/ingredients category delete ingredients

### DIFF
--- a/src/households/models.py
+++ b/src/households/models.py
@@ -17,6 +17,10 @@ class Household(BaseModel):
     def user_is_admin(self, user):
         return HouseholdMember.objects.filter(household=self, user=user).exists()
 
+    def clean(self) -> None:
+        super().clean()
+        self.name = self.name.strip()
+
     def __str__(self) -> str:
         return self.name
 

--- a/src/ingredients/models.py
+++ b/src/ingredients/models.py
@@ -27,6 +27,12 @@ class IngredientsCategory(BaseModel):
         default=False,
     )
 
+    def clean(self) -> None:
+        super().clean()
+        self.name = self.name.strip()
+        if self.description:
+            self.description = self.description.strip()
+
     def __str__(self) -> str:
         return self.name
 
@@ -58,6 +64,10 @@ class Ingredient(BaseModel):
         verbose_name="System Value",
         default=False,
     )
+
+    def clean(self) -> None:
+        super().clean()
+        self.name = self.name.strip()
 
     def __str__(self) -> str:
         return self.name

--- a/src/ingredients/tests/test_ingredient.py
+++ b/src/ingredients/tests/test_ingredient.py
@@ -128,6 +128,20 @@ class TestIngredientList:
         assert not response.context["ingredients"]
         assertContains(response, "no ingredients")
 
+    def test_ingredients_category_uncategorized(
+        self,
+        client: Client,
+        user,
+        household: Household,
+        ingredients_category: IngredientsCategory,
+        ingredient: Ingredient,
+    ):
+        client.login(email=user["email"], password=user["password"])
+        ingredient.category = None
+        ingredient.save()
+        response = client.get(reverse("ingredients:ingredients-list"))
+        assertContains(response, "Uncategorized")
+
 
 @pytest.mark.django_db
 class TestIngredientDelete:

--- a/src/ingredients/tests/test_ingredients_category.py
+++ b/src/ingredients/tests/test_ingredients_category.py
@@ -11,7 +11,7 @@ from pytest_django.asserts import assertContains, assertRedirects
 from households.models import Household
 
 from ..forms import IngredientsCategoryForm
-from ..models import IngredientsCategory
+from ..models import IngredientsCategory, Ingredient
 
 faker = Faker()
 
@@ -156,6 +156,52 @@ class TestIngredientsCategoryDelete:
                 kwargs={"uuid": ingredients_category.uuid},
             ),
         )
+
+    def test_delete_category_without_delete_ingredients_does_not_delete_ingredients(
+        self,
+        user,
+        client: Client,
+        household: Household,
+        ingredients_category: IngredientsCategory,
+        ingredient: Ingredient,
+    ):
+        client.login(email=user["email"], password=user["password"])
+        assert IngredientsCategory.objects.exists()
+        assert Ingredient.objects.exists()
+        client.post(
+            reverse(
+                "ingredients:delete-category",
+                kwargs={
+                    "uuid": ingredients_category.uuid,
+                },
+            ),
+            data={"delete_ingredients": False},
+        )
+        assert not IngredientsCategory.objects.exists()
+        assert Ingredient.objects.exists()
+
+    def test_delete_category_with_delete_ingredients_deletes_ingredients(
+        self,
+        user,
+        client: Client,
+        household: Household,
+        ingredients_category: IngredientsCategory,
+        ingredient: Ingredient,
+    ):
+        client.login(email=user["email"], password=user["password"])
+        assert IngredientsCategory.objects.exists()
+        assert Ingredient.objects.exists()
+        client.post(
+            reverse(
+                "ingredients:delete-category",
+                kwargs={
+                    "uuid": ingredients_category.uuid,
+                },
+            ),
+            data={"delete_ingredients": True},
+        )
+        assert not IngredientsCategory.objects.exists()
+        assert not Ingredient.objects.exists()
 
 
 @pytest.mark.django_db

--- a/src/ingredients/views.py
+++ b/src/ingredients/views.py
@@ -58,6 +58,10 @@ def delete_category(request: HttpRequestWithHousehold, uuid: UUID) -> HttpRespon
     if request.method == "POST":
         form = IngredientsCategoryDeleteForm(request.POST)
         if form.is_valid():
+            if form.cleaned_data["delete_ingredients"]:
+                Ingredient.objects.filter(
+                    household=request.household, category=ic
+                ).delete()
             ic.delete()
             return redirect(reverse_lazy("ingredients:categories-list"))
     context = {"form": form, "category": ic.name}

--- a/src/templates/ingredients/ingredients_list.html
+++ b/src/templates/ingredients/ingredients_list.html
@@ -12,7 +12,7 @@
               <li class="list-group-item">
                 <div class="d-flex justify-content-between">
                   <div class="d-flex flex-wrap gap-2 align-items-baseline">
-                    <span>{{ item }}</span> <span class="small text-secondary">({{ item.category }})</span>
+                    <span>{{ item }}</span> <span class="small text-secondary">({{ item.category|default_if_none:'Uncategorized' }})</span>
                   </div>
                   <div class="d-flex gap-2">
                     <a href="{% url 'ingredients:edit-ingredient' item.uuid %}"><i class="bi bi-pencil"></i><span class="visually-hidden">Edit {{ item }}</span></a>

--- a/src/users/models.py
+++ b/src/users/models.py
@@ -45,6 +45,12 @@ class User(AbstractBaseUser, PermissionsMixin):
     def clean(self):
         super().clean()
         self.email = self.__class__.objects.normalize_email(self.email)  # type: ignore
+        if self.display_name:
+            self.display_name = self.display_name.strip()
+        if self.first_name:
+            self.first_name = self.first_name.strip()
+        if self.last_name:
+            self.last_name = self.last_name.strip()
 
     def get_full_name(self):
         """


### PR DESCRIPTION
This PR adds:
- option for cascading delete for `IngredientsCategory`
- model cleaning (#16)
- editing ingredients category (#15)